### PR TITLE
Fetch files recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,7 @@ If you select 'no', you can also index files in the following ways:
  
 - Inputting a file name with it's namespace e.g. `App/Models/User.php`
 - Inputting a full directory, e.g. `App`
-    - If you pass in a directory, Laragenie can only index files within this directory, and not its subdirectories. 
-    - To index subdirectories you must explicitly pass the path e.g. `App/Models` to index all of your models
+    - If you pass in a directory, Laragenie will index all files, including sudirectories, recursively
 - Inputting multiple files or directories in a comma separated list e.g. `App/Models, tests/Feature, App/Http/Controllers/Controller.php`
 - Inputting multiple directories with wildcards e.g. `App/Models/*.php`
     - Please note that the wildcards must still match the file extensions in your `laragenie` config file.

--- a/src/Helpers/Indexes.php
+++ b/src/Helpers/Indexes.php
@@ -3,9 +3,9 @@
 namespace JoshEmbling\Laragenie\Helpers;
 
 use Illuminate\Support\Str;
-
 use Illuminate\Support\Facades\File;
 use Symfony\Component\Finder\SplFileInfo;
+
 use function Laravel\Prompts\select;
 
 trait Indexes

--- a/src/Helpers/Indexes.php
+++ b/src/Helpers/Indexes.php
@@ -2,8 +2,8 @@
 
 namespace JoshEmbling\Laragenie\Helpers;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
 
 use function Laravel\Prompts\select;

--- a/src/Helpers/Indexes.php
+++ b/src/Helpers/Indexes.php
@@ -4,6 +4,8 @@ namespace JoshEmbling\Laragenie\Helpers;
 
 use Illuminate\Support\Str;
 
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Finder\SplFileInfo;
 use function Laravel\Prompts\select;
 
 trait Indexes
@@ -11,9 +13,9 @@ trait Indexes
     public function getDirectoriesAndFiles(string $user_input): array
     {
         $directories_and_files = [];
-        $extensions = implode(',', config('laragenie.extensions'));
+        $extensions = config('laragenie.extensions');
         $incorrect_paths_and_files = [];
-        $paths = explode(',', $user_input);
+        $paths = explode(',', rtrim($user_input, ','));
 
         foreach ($paths as $path) {
             $path = trim($path);
@@ -21,7 +23,10 @@ trait Indexes
             if (Str::endsWith($path, config('laragenie.extensions'))) {
                 $directory = glob($path);
             } else {
-                $directory = glob($path."/*.{{$extensions}}", GLOB_BRACE);
+                $directory = collect(File::allFiles($path))
+                    ->filter(fn (SplFileInfo $file) => in_array($file->getExtension(), $extensions))
+                    ->map(fn (SplFileInfo $file) => $file->getPathname())
+                    ->toArray();
             }
 
             if ($directory) {


### PR DESCRIPTION
I'm not sure if this was a deliberate decision, but I think it makes sense for files to be retrieved recursively, because in many scenarios the files in the source code are split across lots of directories and specifying all of them is hard work and requires a lot more upkeep.

If you didn't want this to be the default, another option could be to have a `recursive` config option which defaults to false. 

~~Unrelated but the other thing I noticed immediately is that the OpenAI API seems to regularly flake out with "Service Unavailable" exceptions. Not sure if I just got unlucky with my timing or if this is normal; if it is normal perhaps a `retry()` could help to avoid having to restart a large indexing operation from scratch (assuming one of retries is successful)~~

Nevermind, I the OpenAI API was having issues yesterday