### PR TITLE
Update OpenAI models in config to latest versions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ return [
         ],
         'chat' => [
             'model' => 'gpt-4-turbo-preview', // Your OpenAI GPT model
-            'temperature' => 0.1, // Set temperature on the model
+            'temperature' => 0.1, // Set temperature between 0 and 1 (lower values will have less irrelevance)
         ],
     ],
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ return [
 
     'openai' => [
         'embedding' => [
-            'model' => 'text-embedding-ada-002', // Text embedding model 
+            'model' => 'text-embedding-3-small', // Text embedding model 
             'max_tokens' => 5, // Maximum tokens to use when embedding
         ],
         'chat' => [
-            'model' => 'gpt-4-1106-preview', // Your OpenAI GPT model
+            'model' => 'gpt-4-turbo-preview', // Your OpenAI GPT model
             'temperature' => 0.1, // Set temperature on the model
         ],
     ],

--- a/config/laragenie.php
+++ b/config/laragenie.php
@@ -33,11 +33,11 @@ return [
 
     'openai' => [
         'embedding' => [
-            'model' => 'text-embedding-ada-002',
+            'model' => 'text-embedding-3-small',
             'max_tokens' => 5,
         ],
         'chat' => [
-            'model' => 'gpt-4-1106-preview',
+            'model' => 'gpt-4-turbo-preview',
             'temperature' => 0.1,
         ],
     ],


### PR DESCRIPTION
As of 25th January 2024 we have new embedding model which is 5X cheaper and offers improved performance.

Set chat model to an alias that always ensures latest GPT-4 model. 

More info https://openai.com/blog/new-embedding-models-and-api-updates