### PR TITLE
Change conditions order in Questions.php

### DIFF
--- a/src/Helpers/Questions.php
+++ b/src/Helpers/Questions.php
@@ -26,7 +26,7 @@ trait Questions
             ]);
         }
 
-        if ($laragenie->exists && config('laragenie.database.fetch') && ! $ai) {
+        if (config('laragenie.database.fetch') && $laragenie->exists && ! $ai) {
             $this->textOutput($laragenie->answer);
         } else {
             $results = (array) $this->askBot($formattedQuestion);


### PR DESCRIPTION
When `laragenie.database.fetch` and `laragenie.databse.save` config are set to false, `$laragenie` is not set on Questions.php line 29.

Inverting conditions fixes the issue.